### PR TITLE
trigger build on every push 

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,9 +1,7 @@
 name: Create and publish Container images
 
 on:
-  push:
-    tags:
-      - v*
+  push
 
 jobs:
   build-container-images:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.21
+          go-version: 1.22
           cache: true
 
       - name: Build amd64

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,7 +5,6 @@ on:
 
 jobs:
   build-container-images:
-    if: ${{ github.repository_owner }} == "varbhat"
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,7 +1,14 @@
 name: Create and publish Container images
 
 on:
-  push
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+  push:
+    branches:
+      - "main"
 
 jobs:
   build-container-images:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,7 +25,7 @@ jobs:
           tags: |
             type=raw,value=amd64
             type=raw,value=arm64
-            type=raw,value=latest
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
             type=schedule
             type=ref,event=branch
             type=ref,event=pr

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,6 +3,9 @@ name: Create and publish Container images
 on:
   push
 
+env:
+  HAS_TAG: ${{startsWith(github.ref, 'refs/tags/v')}}
+
 jobs:
   build-container-images:
     runs-on: ubuntu-latest
@@ -25,7 +28,7 @@ jobs:
           tags: |
             type=raw,value=amd64
             type=raw,value=arm64
-            type=raw,value=latest
+            type=raw,value=latest,enable=${{env.HAS_TAG}}
             type=schedule
             type=ref,event=branch
             type=ref,event=pr
@@ -144,7 +147,7 @@ jobs:
       - build-binaries-linux
       - build-binaries-darwin
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: ${{env.HAS_TAG}}
     permissions:
       contents: write
     steps:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,9 +3,6 @@ name: Create and publish Container images
 on:
   push
 
-env:
-  HAS_TAG: ${{startsWith(github.ref, 'refs/tags/v')}}
-
 jobs:
   build-container-images:
     runs-on: ubuntu-latest
@@ -28,7 +25,7 @@ jobs:
           tags: |
             type=raw,value=amd64
             type=raw,value=arm64
-            type=raw,value=latest,enable=${{env.HAS_TAG}}
+            type=raw,value=latest
             type=schedule
             type=ref,event=branch
             type=ref,event=pr
@@ -147,7 +144,7 @@ jobs:
       - build-binaries-linux
       - build-binaries-darwin
     runs-on: ubuntu-latest
-    if: ${{env.HAS_TAG}}
+    if: startsWith(github.ref, 'refs/tags/v')
     permissions:
       contents: write
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ADD Makefile /exa/
 RUN make web
 
 # Build the application from source
-FROM docker.io/golang:1.21-bookworm AS build-go
+FROM docker.io/golang:1.22-bookworm AS build-go
 
 ARG TARGETOS TARGETARCH
 


### PR DESCRIPTION
trigger build on every push to make sure every commit can compile successfully
it will **only** push docker image with tag `latest` on tagged push 
but it will consume more github action minutes, it may cost money or disabled if exceed [free usage limit](https://docs.github.com/en/get-started/learning-about-github/githubs-plans#github-free-for-personal-accounts)
