### PR TITLE
fix: wrong version

### DIFF
--- a/internal/core/version.go
+++ b/internal/core/version.go
@@ -1,3 +1,3 @@
 package core
 
-const Version string = "v1.1.0"
+const Version string = "v1.3.0"


### PR DESCRIPTION
fix wrong app version to v1.3.0 

or maybe we can set Version variable via -ldflags -X at build time 