### PR TITLE
fix: unsupported macos version 11, upgrade to version 12

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -63,7 +63,7 @@ jobs:
             *.cache-to=type=gha,mode=max
 
   build-binaries-darwin:
-    runs-on: macos-11
+    runs-on: macos-12
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
according to github action warning The macOS-11 environment is deprecated and will be removed on June 28th, 2024.

update to macos-12