### PR TITLE
remove user len check

### DIFF
--- a/internal/core/auth.go
+++ b/internal/core/auth.go
@@ -118,7 +118,7 @@ func bauthHelper(w http.ResponseWriter, r *http.Request) (username string, usert
 		return "", -1, "", fmt.Errorf("not authorized")
 	}
 
-	if len(username) < 5 || len(password) < 5 {
+	if len(username) == 0 || len(password) < 5 {
 		http.Error(w, "Not authorized", http.StatusUnauthorized)
 		return "", -1, "", fmt.Errorf("not authorized")
 	}
@@ -161,7 +161,7 @@ func rauthHelper(w http.ResponseWriter, r *http.Request) (username string, usert
 	if err != nil {
 		return "", -1, "", err
 	}
-	if len(cred.Data1) < 5 || len(cred.Data2) < 5 {
+	if len(cred.Data1) == 0 || len(cred.Data2) < 5 {
 		return "", -1, "", fmt.Errorf("invalid credentials")
 	}
 	usertype, ok = Engine.UDb.Validate(cred.Data1, cred.Data2)

--- a/internal/core/socket.go
+++ b/internal/core/socket.go
@@ -126,7 +126,7 @@ func wshandler(uc *UserConn, req *ConReq) {
 		case "deletetorrent":
 		//
 		case "adduser":
-			if !(len(req.Data1) > 5 || len(req.Data2) > 5) {
+			if !(len(req.Data1) == 0 || len(req.Data2) > 5) {
 				_ = uc.SendMsg("resp", "error", "length of username and password must be more than 5")
 				return
 			}
@@ -149,7 +149,7 @@ func wshandler(uc *UserConn, req *ConReq) {
 			Info.Println("New User ", req.Data1, " added by ", uc.Username)
 			return
 		case "removeuser":
-			if !(len(req.Data1) > 5) {
+			if len(req.Data1) == 0 {
 				_ = uc.SendMsg("resp", "error", "length of username  must be more than 5")
 				return
 			}

--- a/internal/db/psqluserdb.go
+++ b/internal/db/psqluserdb.go
@@ -37,7 +37,7 @@ func (db *PsqlUserDb) Add(Username string, Password string, UserType int) (err e
 			err = fmt.Errorf("uuid error") // uuid may panic
 		}
 	}()
-	if len(Username) <= 5 || len(Password) <= 5 {
+	if len(Username) == 0 || len(Password) <= 5 {
 		return fmt.Errorf("username or password size too small")
 	}
 	bytes, err := bcrypt.GenerateFromPassword([]byte(Password), 10)

--- a/internal/db/sqlite3userdb.go
+++ b/internal/db/sqlite3userdb.go
@@ -49,7 +49,7 @@ func (db *Sqlite3UserDb) Add(Username string, Password string, UserType int) (er
 			err = fmt.Errorf("uuid error") // uuid may panic
 		}
 	}()
-	if len(Username) <= 5 || len(Password) <= 5 {
+	if len(Username) == 0 || len(Password) <= 5 {
 		return fmt.Errorf("username or password size too small")
 	}
 	bytes, err := bcrypt.GenerateFromPassword([]byte(Password), 10)

--- a/internal/web/src/partials/Signin.svelte
+++ b/internal/web/src/partials/Signin.svelte
@@ -27,7 +27,7 @@
   function signIn() {
     if (exausername != '' && exausername != undefined && exausername != null) {
       if (exapassword != '' && exapassword != undefined && exapassword != null) {
-        if (!(exausername.length > 5) || !(exapassword.length > 5)) {
+        if (!(exausername.length > 0) || !(exapassword.length > 5)) {
           alert('Invalid Credentials');
           return;
         }

--- a/internal/web/src/partials/core.ts
+++ b/internal/web/src/partials/core.ts
@@ -240,7 +240,7 @@ export let Connect = () => {
     return;
   }
 
-  if (!(un.length > 5) || !(pw.length > 5)) {
+  if (!(un.length > 0) || !(pw.length > 5)) {
     alert('Invalid Credentials');
     return;
   }


### PR DESCRIPTION
The user can have a login less than 5 characters (as an example - my login is Slex)
Added a check for an empty login, removed the check for 5 characters

In the future, we can get rid of the "magic" constants and move them to a separate file.